### PR TITLE
Fix typo in function name

### DIFF
--- a/layouts/partials/typeIndex.html
+++ b/layouts/partials/typeIndex.html
@@ -52,7 +52,7 @@
     const ps1Delay = parseDelay("{{ .ps1delay }}"),
         stdoutDelay = parseDelay("{{ .stdoutdelay }}"),
         commandDelay = parseDelay("{{ .commanddelay }}");
-    const typeeffetct = async () => {
+    const typeeffect = async () => {
         await typewriter("{{ .env }}", "ps1_01", ps1Delay); await typewriter("{{ .cd }}", "cd", commandDelay);
         await typewriter("{{ .envWithDir }}", "ps1_02", ps1Delay); await typewriter("{{ .cat }}", "cat", commandDelay);
         await typewriter("{{ .description }}", "std_out_01", stdoutDelay);
@@ -62,5 +62,5 @@
         return;
     }
 
-    typeeffetct()
+    typeeffect()
 </script>


### PR DESCRIPTION
`typeeffetct` -> `typeeffect`

Should be a non-breaking change.